### PR TITLE
CP-462 feat: implement local native option to run outside docker compose.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,27 @@ val-0-start:
 val-0-clean:
 	injectived --home="./chain-stresser-deploy/validators/0" tendermint unsafe-reset-all
 
+val-1-start:
+	injectived --home="./chain-stresser-deploy/validators/1" start
+
+val-1-clean:
+	injectived --home="./chain-stresser-deploy/validators/1" tendermint unsafe-reset-all
+
+val-2-start:
+	injectived --home="./chain-stresser-deploy/validators/2" start
+
+val-2-clean:
+	injectived --home="./chain-stresser-deploy/validators/2" tendermint unsafe-reset-all
+
+val-3-start:
+	injectived --home="./chain-stresser-deploy/validators/3" start
+
+val-3-clean:
+	injectived --home="./chain-stresser-deploy/validators/3" tendermint unsafe-reset-all
+
+gen-4-native:
+	chain-stresser generate --accounts-num 1000 --validators 4 --sentries 0 --instances 1 --evm true --native
+
 compose-up:
 	docker compose -f chain-stresser-deploy/docker-compose.yml up -d
 

--- a/chain/config_app.go
+++ b/chain/config_app.go
@@ -15,6 +15,7 @@ type AppConfig struct {
 	ProdLike         bool
 
 	IPListen     net.IP
+	Ports        Ports
 	PortsExposed bool
 }
 

--- a/chain/config_node.go
+++ b/chain/config_node.go
@@ -82,18 +82,19 @@ func (nodeConfig *NodeConfig) Save(homeDir string) {
 	cfg.RPC.MaxOpenConnections = 10000
 	cfg.RPC.MaxSubscriptionsPerClient = 10000
 	cfg.Mempool.Size = 50000
-  cfg.Mempool.MaxTxsBytes = 671088640
+	cfg.Mempool.MaxTxsBytes = 671088640
+
+	cfg.P2P.ListenAddress = "tcp://" + net.JoinHostPort(
+		nodeConfig.IPListen.String(),
+		strconv.Itoa(nodeConfig.Ports.P2P),
+	)
+
+	cfg.RPC.ListenAddress = "tcp://" + net.JoinHostPort(
+		nodeConfig.IPListen.String(),
+		strconv.Itoa(nodeConfig.Ports.RPC),
+	)
 
 	if nodeConfig.PortsExposed {
-		cfg.P2P.ListenAddress = "tcp://" + net.JoinHostPort(
-			nodeConfig.IPListen.String(),
-			strconv.Itoa(nodeConfig.Ports.P2P),
-		)
-		cfg.RPC.ListenAddress = "tcp://" + net.JoinHostPort(
-			nodeConfig.IPListen.String(),
-			strconv.Itoa(nodeConfig.Ports.RPC),
-		)
-
 		cfg.Instrumentation.Prometheus = true
 		cfg.Instrumentation.PrometheusListenAddr = net.JoinHostPort(
 			nodeConfig.IPListen.String(),

--- a/chain/init.go
+++ b/chain/init.go
@@ -20,6 +20,7 @@ var DefaultPorts = Ports{
 	Prometheus: 26660,
 	EVMRPC:     8545,
 	EVMWSPort:  8546,
+	ProxyApp:   26658,
 }
 
 func setAccountPrefixes(accountAddressPrefix string) {

--- a/chain/templates/app.evm.toml.tpl
+++ b/chain/templates/app.evm.toml.tpl
@@ -133,7 +133,7 @@ enable = true
 swagger = true
 
 # Address defines the API server to listen on.
-address = "tcp://{{.IPListen}}:10337"
+address = "tcp://{{.IPListen}}:{{.Ports.API}}"
 
 # MaxOpenConnections defines the number of maximum open connections.
 max-open-connections = 1000
@@ -160,7 +160,7 @@ enabled-unsafe-cors = true
 enable = true
 
 # Address defines the gRPC server address to bind to.
-address = "{{.IPListen}}:9900"
+address = "{{.IPListen}}:{{.Ports.GRPC}}"
 
 # MaxRecvMsgSize defines the max message size in bytes the server can receive.
 # The default value is 10MB.
@@ -205,10 +205,10 @@ max-tx-gas-wanted = 0
 enable = true
 
 # Address defines the EVM RPC HTTP server address to bind to.
-address = "{{.IPListen}}:8545"
+address = "{{.IPListen}}:{{.Ports.EVMRPC}}"
 
 # Address defines the EVM WebSocket server address to bind to.
-ws-address = "{{.IPListen}}:8546"
+ws-address = "{{.IPListen}}:{{.Ports.EVMWSPort}}"
 
 # API defines a list of JSON-RPC namespaces that should be enabled
 # Example: "eth,txpool,personal,net,debug,web3"

--- a/chain/templates/app.prod.toml.tpl
+++ b/chain/templates/app.prod.toml.tpl
@@ -107,7 +107,7 @@ enable = true
 swagger = true
 
 # Address defines the API server to listen on.
-address = "tcp://{{.IPListen}}:10337"
+address = "tcp://{{.IPListen}}:{{.Ports.API}}"
 
 # MaxOpenConnections defines the number of maximum open connections.
 max-open-connections = 1000
@@ -134,7 +134,7 @@ enabled-unsafe-cors = false
 enable = true
 
 # Address defines the gRPC server address to bind to.
-address = "{{.IPListen}}:9900"
+address = "{{.IPListen}}:{{.Ports.GRPC}}"
 
 [grpc-web]
 
@@ -142,7 +142,7 @@ address = "{{.IPListen}}:9900"
 enable = true
 
 # Address defines the gRPC Web server address to bind to.
-address = "{{.IPListen}}:9091"
+address = "{{.IPListen}}:{{.Ports.GRPCWeb}}"
 
 ###############################################################################
 ###                        State Sync Configuration                         ###

--- a/chain/templates/app.toml.tpl
+++ b/chain/templates/app.toml.tpl
@@ -107,7 +107,7 @@ enable = true
 swagger = true
 
 # Address defines the API server to listen on.
-address = "tcp://{{.IPListen}}:10337"
+address = "tcp://{{.IPListen}}:{{.Ports.API}}"
 
 # MaxOpenConnections defines the number of maximum open connections.
 max-open-connections = 1000
@@ -134,7 +134,7 @@ enabled-unsafe-cors = false
 enable = true
 
 # Address defines the gRPC server address to bind to.
-address = "{{.IPListen}}:9900"
+address = "{{.IPListen}}:{{.Ports.GRPC}}"
 
 [grpc-web]
 
@@ -142,7 +142,7 @@ address = "{{.IPListen}}:9900"
 enable = true
 
 # Address defines the gRPC Web server address to bind to.
-address = "{{.IPListen}}:9091"
+address = "{{.IPListen}}:{{.Ports.GRPCWeb}}"
 
 ###############################################################################
 ###                        State Sync Configuration                         ###

--- a/chain/templates/config.prod.toml.tpl
+++ b/chain/templates/config.prod.toml.tpl
@@ -16,7 +16,7 @@ version = "1.0.1"
 
 # TCP or UNIX socket address of the ABCI application,
 # or the name of an ABCI application compiled in with the CometBFT binary
-proxy_app = "tcp://127.0.0.1:26658"
+proxy_app = "tcp://127.0.0.1:{{.Ports.ProxyApp}}"
 
 # A custom human readable name for this node
 moniker = "{{.Moniker}}"
@@ -91,7 +91,7 @@ filter_peers = false
 [rpc]
 
 # TCP or UNIX socket address for the RPC server to listen on
-laddr = "tcp://{{.IPListen}}:26657"
+laddr = "tcp://{{.IPListen}}:{{.Ports.RPC}}"
 
 # A list of origins a cross-domain request can be executed from
 # Default value '[]' disables cors support
@@ -185,7 +185,7 @@ tls_cert_file = ""
 tls_key_file = ""
 
 # pprof listen address (https://golang.org/pkg/net/http/pprof)
-pprof_laddr = "localhost:6060"
+pprof_laddr = "{{.IPListen}}:{{.Ports.PProf}}"
 
 #######################################################
 ###       gRPC Server Configuration Options         ###
@@ -253,7 +253,7 @@ enabled = false
 [p2p]
 
 # Address to listen for incoming connections
-laddr = "tcp://{{.IPListen}}:26656"
+laddr = "tcp://{{.IPListen}}:{{.Ports.P2P}}"
 
 # Address to advertise to peers for them to dial. If empty, will use the same
 # port as the laddr, and will introspect on the listener to figure out the
@@ -597,7 +597,7 @@ psql-conn = ""
 prometheus = false
 
 # Address to listen for Prometheus collector(s) connections
-prometheus_listen_addr = "{{.IPListen}}:26660"
+prometheus_listen_addr = "{{.IPListen}}:{{.Ports.Prometheus}}"
 
 # Maximum number of simultaneous connections.
 # If you want to accept a larger number than the default, make sure

--- a/chain/types.go
+++ b/chain/types.go
@@ -16,6 +16,7 @@ type Ports struct {
 	Prometheus int `json:"prometheus"`
 	EVMRPC     int `json:"evmRpc"`
 	EVMWSPort  int `json:"evmWsPort"`
+	ProxyApp   int `json:"proxyApp"`
 }
 
 type Account struct {

--- a/cmd/chain-stresser/main.go
+++ b/cmd/chain-stresser/main.go
@@ -100,6 +100,15 @@ func main() {
 				log.DefaultLogger.SetLevel(log.DebugLevel)
 			}
 
+			if genEnv.LocalNative {
+				if genEnv.NumOfValidators > 4 {
+					return errors.New("number of validators must be less than or equal to 4 when running natively")
+				}
+				if genEnv.NumOfSentryNodes > 0 {
+					return errors.New("number of sentry nodes must be 0 when running natively")
+				}
+			}
+
 			stresser.GenerateConfigs(genEnv)
 			return nil
 		},
@@ -115,6 +124,7 @@ func main() {
 	generateCmd.Flags().IntVar(&genEnv.NumOfValidators, "validators", defaultNumOfValidators, "Number of validators to generate config for.")
 	generateCmd.Flags().IntVar(&genEnv.NumOfSentryNodes, "sentries", defaultNumOfSentries, "Number of sentry nodes to generate config for.")
 	generateCmd.Flags().IntVar(&genEnv.NumOfInstances, "instances", defaultNumOfInstances, "The maximum number of parallel chain-stresser instances to be prepared for.")
+	generateCmd.Flags().BoolVar(&genEnv.LocalNative, "native", false, "Generate config compatible with running multiple binaries natively on the host machine (no docker-compose).")
 	generateCmd.Flags().IntVar(&genEnv.NumOfAccountsPerInstance, "accounts-num", defaultNumOfAccounts, "Number of funded accounts to generate for each instance.")
 	generateCmd.Flags().StringVar(&genEnv.OutDirectory, "out", strOrPanic(os.Getwd()), "Path to the directory where generated files are stored.")
 	rootCmd.AddCommand(generateCmd)

--- a/generator.go
+++ b/generator.go
@@ -26,6 +26,7 @@ type GeneratorEnvironment struct {
 	OutDirectory             string
 	ProdLike                 bool
 	Debug                    bool
+	LocalNative              bool
 }
 
 const (
@@ -85,13 +86,23 @@ func GenerateConfigs(
 			txIndexerKind = chain.TxIndexerDisabled
 		}
 
+		nodeIPAddr := net.IPv4(127, 0, 0, 1)
+		if !env.LocalNative {
+			nodeIPAddr = ipInSubnet(env.DockerSubnet, i+1)
+		}
+
+		nodePorts := chain.DefaultPorts
+		if env.LocalNative {
+			nodePorts = shiftPorts(nodePorts, i)
+		}
+
 		nodeConfig := &chain.NodeConfig{
 			Home:                 fmt.Sprintf("./%s", relativeNodeDir),
 			Moniker:              fmt.Sprintf("validator-%d", i),
 			PeerID:               chain.NodeID(nodePrivateKey.PubKey()),
 			IPListen:             net.IPv4zero,
-			IPAddr:               ipInSubnet(env.DockerSubnet, i+1),
-			Ports:                chain.DefaultPorts,
+			IPAddr:               nodeIPAddr,
+			Ports:                nodePorts,
 			NodeKey:              nodePrivateKey,
 			ValidatorKey:         validatorPrivateKey,
 			ProdLike:             env.ProdLike,
@@ -112,6 +123,7 @@ func GenerateConfigs(
 			EVMEnabled:       env.EvmEnabled,
 			ProdLike:         env.ProdLike,
 			IPListen:         net.IPv4zero,
+			Ports:            nodePorts,
 			PortsExposed:     env.NumOfSentryNodes == 0 && i == 0, // expose ports only for the first validator (and no sentry nodes)
 		}
 		appConfig.Save(valDir)
@@ -171,6 +183,7 @@ func GenerateConfigs(
 				EVMEnabled:       env.EvmEnabled,
 				ProdLike:         env.ProdLike,
 				IPListen:         net.IPv4zero,
+				Ports:            chain.DefaultPorts,
 				PortsExposed:     i == 0, // expose ports only for the first sentry node
 			}
 
@@ -198,14 +211,16 @@ func GenerateConfigs(
 		nodeConfig.Save(filepath.Join(rootOutDir, nodeConfig.Home))
 	}
 
-	chain.GenerateDockerCompose(
-		env.ChainID,
-		env.DockerImage,
-		env.DockerSubnet,
-		allNodeConfigs,
-		rootOutDir,
-		env.Debug,
-	)
+	if !env.LocalNative {
+		chain.GenerateDockerCompose(
+			env.ChainID,
+			env.DockerImage,
+			env.DockerSubnet,
+			allNodeConfigs,
+			rootOutDir,
+			env.Debug,
+		)
+	}
 }
 
 func filterStringValue(list []string, filter string) []string {
@@ -235,6 +250,24 @@ func ipInSubnet(subnet string, offset int) net.IP {
 	ip[3] += byte(offset + 1) // +1 because we want to start from the second IP in the subnet (not gateway)
 
 	return ip
+}
+
+func shiftPorts(ports chain.Ports, offset int) chain.Ports {
+	// digitOffset is 100 then 26657 -> 26757 -> 26857 -> 26957
+	const digitOffset = 100
+
+	return chain.Ports{
+		RPC:        ports.RPC + digitOffset*offset,
+		P2P:        ports.P2P + digitOffset*offset,
+		API:        ports.API + digitOffset*offset,
+		GRPC:       ports.GRPC + digitOffset*offset,
+		GRPCWeb:    ports.GRPCWeb + digitOffset*offset,
+		PProf:      ports.PProf + digitOffset*offset,
+		Prometheus: ports.Prometheus + digitOffset*offset,
+		EVMRPC:     ports.EVMRPC + digitOffset*offset,
+		EVMWSPort:  ports.EVMWSPort + digitOffset*offset,
+		ProxyApp:   ports.ProxyApp + digitOffset*offset,
+	}
 }
 
 func makeIntRange(start, end int) []int {


### PR DESCRIPTION
Added `--native` option that can be used like this:
```
chain-stresser generate --accounts-num 1000 --validators 4 --sentries 0 --instances 1 --evm true --native
```

The generator will skip creating docker compose config and will make sure everything runs locally on the same host and the ports don't collide

## Example

```bash
make gen-4-native # generates a 4 validators network

make val-0-start # 1st tab
make val-1-start # 2nd tab
make val-2-start # 3rd tab
make val-3-start # 4th tab
```

The RPCs are exposed with ports shifted by `+ 100*idx` (all ports are shifted like that)

- **http://localhost:26657**
- http://localhost:26757
- http://localhost:26857
- http://localhost:26957

## Limitations

- No sentry nodes (altough easy to add if really needed, I decided to not overcomplicate for this rare case)
- No more than 4 validators (if you need to run more, switch to virtualized docker compose setup)

## Pro tips

Use `make val-*-clean` to reset particular node dir to the genesis state (iterate to reset them all).

`make val-0-start` works for both `--native` and docker compose based setups, because the main problem with native setup is ports collision on localhost, but a single validator won't collide with anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for launching and cleaning multiple validator nodes (up to 4) with new commands.
	- Introduced a "native" mode for configuration generation, enabling local multi-validator setups with dynamic port and IP assignments.
	- Added a new CLI flag for native mode and validation for supported node configurations.
- **Configuration**
	- All relevant configuration templates now use dynamic port assignments, allowing flexible port customization for services.
- **Bug Fixes**
	- Improved logic to ensure service addresses are always set, regardless of port exposure settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->