### PR TITLE
[CP-588] Add's ratelimiter pkg that supports TPS bytes and gas limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Flags:
   -h, --help                   help for chain-stresser
       --min-gas-price string   Minimum gas price to pay for each transaction. (default "1inj")
       --node-addr string       Address of a injectived node RPC to connect to. (default "localhost:26657")
+      --rate-tps float         Rate limit transactions per second. Example: 200 for 200 TPS, 99.5 for fractional rates. 0 = no limit.
+      --rate-bytes uint        Rate limit transaction bandwidth in bytes per second. Example: 50000 for 50KB/sec. 0 = no limit.
+      --rate-gas uint          Rate limit gas consumption per second. Example: 1000000 for 1M gas/sec. 0 = no limit.
+      --rate-burst-size int    Custom burst size (tokens). If >0, overrides default burst calculation. 0 = auto.
       --transactions int       Number of transactions to allocate for each account. (default 100)
 
 Use "chain-stresser [command] --help" for more information about a command.
@@ -53,6 +57,145 @@ Run a stress test against this node (in separate tab):
 ```
 chain-stresser tx-bank-send --accounts ./chain-stresser-deploy/instances/0/accounts.json
 ```
+
+## Rate Limiting (Optional)
+
+Control the stress test intensity with built-in rate limiting. You can limit by transactions per second, bandwidth, or gas consumption.
+
+**Load Generation Pipeline:**
+1. **`--accounts-num`** and **`--transactions`** control the total load generated (pipeline capacity)
+2. **Rate limits** act as "nozzles" controlling how fast that load flows through
+
+**Example:** 100 accounts × 50 transactions = 5,000 total transactions → rate limiting controls delivery speed
+
+### Transaction Rate Limiting
+
+```bash
+# Limit to 100 transactions per second with 10 accounts sending 50 transactions each
+chain-stresser tx-bank-send \
+  --rate-tps 100 \
+  --accounts ./accounts.json \
+  --accounts-num 10 \
+  --transactions 50
+
+# Fractional rates (0.5 TPS = one transaction every 2 seconds)
+chain-stresser tx-bank-send \
+  --rate-tps 0.5 \
+  --accounts ./accounts.json \
+  --accounts-num 5 \
+  --transactions 10
+
+# Very high rate for maximum stress (1000 accounts × 100 tx = 100K total transactions)
+chain-stresser tx-bank-send \
+  --rate-tps 1000 \
+  --accounts ./accounts.json \
+  --accounts-num 1000 \
+  --transactions 100
+```
+
+### Bandwidth Rate Limiting
+
+```bash
+# Limit to 50KB/sec transaction bandwidth with moderate load
+chain-stresser tx-bank-send \
+  --rate-bytes 50000 \
+  --accounts ./accounts.json \
+  --accounts-num 20 \
+  --transactions 100
+
+# 1MB/sec bandwidth limit with high load generation
+chain-stresser tx-bank-send \
+  --rate-bytes 1048576 \
+  --accounts ./accounts.json \
+  --accounts-num 500 \
+  --transactions 200
+```
+
+### Gas Rate Limiting
+
+```bash
+# Limit to 1 million gas units per second with moderate load
+chain-stresser tx-bank-send \
+  --rate-gas 1000000 \
+  --accounts ./accounts.json \
+  --accounts-num 50 \
+  --transactions 100
+
+# Conservative gas limiting for ETH contract deployment capacity testing
+chain-stresser tx-eth-deploy \
+  --rate-gas 500000 \
+  --accounts ./accounts.json \
+  --accounts-num 10 \
+  --transactions 20
+```
+
+### Combined Rate Limiting
+
+Rate limits work together as multiple "nozzles" controlling the transaction flow. **The first limit to be reached becomes the bottleneck** that controls the overall rate:
+
+```bash
+# Apply multiple limits simultaneously with moderate load generation
+chain-stresser tx-bank-send \
+  --rate-tps 50 \
+  --rate-bytes 100000 \
+  --rate-gas 2000000 \
+  --rate-burst-size 100 \
+  --accounts ./accounts.json \
+  --accounts-num 100 \
+  --transactions 50
+
+# Network capacity testing with realistic limits and high load generation
+chain-stresser tx-eth-call \
+  --rate-tps 200 \
+  --rate-gas 5000000 \
+  --accounts ./accounts.json \
+  --accounts-num 200 \
+  --transactions 1000
+```
+
+**How multiple limits interact:**
+- Each transaction must pass **all three checks**: TPS, bytes, and gas
+- If TPS limit allows 100 tx/sec but gas limit only allows 50 tx/sec worth of gas → **gas limit wins** (50 tx/sec)
+- If bytes limit allows 10 tx/sec but TPS allows 100 tx/sec → **bytes limit wins** (10 tx/sec)
+- The **most restrictive limit** determines the actual throughput
+
+**Example:** Bank sends use ~150K gas and ~500 bytes each:
+```bash
+--rate-tps 100 --rate-bytes 10000 --rate-gas 1000000
+# TPS allows:   100 tx/sec
+# Bytes allows: 10000÷500 = 20 tx/sec  ← BOTTLENECK  
+# Gas allows:   1000000÷150000 = 6.6 tx/sec  ← ACTUAL BOTTLENECK
+# Result: ~6.6 tx/sec (gas limit wins)
+```
+
+### Burst Configuration (Optional)
+
+```bash
+# Auto-calculated burst (default behavior, recommended)
+chain-stresser tx-bank-send \
+  --rate-tps 100 \
+  --accounts ./accounts.json \
+  --accounts-num 50 \
+  --transactions 100
+
+# Manual burst size (allows 50 transactions at once, then rate limited)
+chain-stresser tx-bank-send \
+  --rate-tps 100 \
+  --rate-burst-size 50 \
+  --accounts ./accounts.json \
+  --accounts-num 50 \
+  --transactions 100
+
+# Large burst for bursty workloads
+chain-stresser tx-eth-deploy \
+  --rate-gas 1000000 \
+  --rate-burst-size 500000 \
+  --accounts ./accounts.json \
+  --accounts-num 20 \
+  --transactions 50
+```
+
+**Note:** Rate limiting works for all transaction types**
 
 ## Querying EVM State
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ chain-stresser tx-eth-call \
 - Each transaction must pass **all three checks**: TPS, bytes, and gas
 - If TPS limit allows 100 tx/sec but gas limit only allows 50 tx/sec worth of gas → **gas limit wins** (50 tx/sec)
 - If bytes limit allows 10 tx/sec but TPS allows 100 tx/sec → **bytes limit wins** (10 tx/sec)
-- The **most restrictive limit** determines the actual throughput
+- The **most restrictive limit** determines the actual throughput and they are all optional (default 0, defines no limit).
 
 **Example:** Bank sends use ~150K gas and ~500 bytes each:
 ```bash

--- a/cmd/chain-stresser/main.go
+++ b/cmd/chain-stresser/main.go
@@ -90,6 +90,7 @@ func main() {
 	// Rate limiting flags
 	rootCmd.PersistentFlags().Float64Var(&stressCfg.RateLimit.TxPerSecond, "rate-tps", 0, "Rate limit transactions per second. Example: 200 for 200 TPS, 99.5 for fractional rates. 0 = no limit.")
 	rootCmd.PersistentFlags().Uint64Var(&stressCfg.RateLimit.BytesPerSecond, "rate-bytes", 0, "Rate limit transaction bandwidth in bytes per second. Example: 50000 for 50KB/sec. 0 = no limit.")
+	rootCmd.PersistentFlags().Uint64Var(&stressCfg.RateLimit.GasPerSecond, "rate-gas", 0, "Rate limit gas consumption per second. Example: 1000000 for 1M gas/sec. 0 = no limit.")
 	rootCmd.PersistentFlags().IntVar(&stressCfg.RateLimit.Burst.Size, "rate-burst-size", 0, "Custom burst size (tokens). If >0, overrides default burst calculation. 0 = auto.")
 
 	rootCmd.SetHelpCommand(&cobra.Command{

--- a/cmd/chain-stresser/main.go
+++ b/cmd/chain-stresser/main.go
@@ -86,6 +86,12 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&accountFile, "accounts", "accounts.json", "Path to a JSON file containing private keys of accounts to use for stress testing.")
 	rootCmd.PersistentFlags().IntVar(&numOfAccounts, "accounts-num", defaultNumOfAccounts, "Number of accounts used to benchmark the node in parallel, must not be greater than the number of keys available in account file.")
 	rootCmd.PersistentFlags().IntVar(&stressCfg.NumOfTransactions, "transactions", defaultNumOfTx, "Number of transactions to allocate for each account.")
+
+	// Rate limiting flags
+	rootCmd.PersistentFlags().Float64Var(&stressCfg.RateLimit.TxPerSecond, "rate-tps", 0, "Rate limit transactions per second. Example: 200 for 200 TPS, 99.5 for fractional rates. 0 = no limit.")
+	rootCmd.PersistentFlags().Uint64Var(&stressCfg.RateLimit.BytesPerSecond, "rate-bytes", 0, "Rate limit transaction bandwidth in bytes per second. Example: 50000 for 50KB/sec. 0 = no limit.")
+	rootCmd.PersistentFlags().IntVar(&stressCfg.RateLimit.Burst.Size, "rate-burst-size", 0, "Custom burst size (tokens). If >0, overrides default burst calculation. 0 = auto.")
+
 	rootCmd.SetHelpCommand(&cobra.Command{
 		Hidden: true,
 	})

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/xlab/closer v1.1.0
 	github.com/xlab/pace v1.1.0
 	github.com/xlab/suplog v1.4.4
-	github.com/ybbus/jsonrpc/v3 v3.1.6
 	google.golang.org/grpc v1.71.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -794,8 +794,6 @@ github.com/xlab/suplog/hooks/bugsnag v0.0.0-20220720111129-da4fb2555fa2 h1:w4IOI
 github.com/xlab/suplog/hooks/bugsnag v0.0.0-20220720111129-da4fb2555fa2/go.mod h1:LuRWPshv3h7aCxkeJpmWvyQsRlSygru9kuyjJ8oDqYw=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
-github.com/ybbus/jsonrpc/v3 v3.1.6 h1:Yn2dNOZ3xVdOVxq9d4GaH2pxjjei27C+vU6H+E7hfAw=
-github.com/ybbus/jsonrpc/v3 v3.1.6/go.mod h1:U1QbyNfL5Pvi2roT0OpRbJeyvGxfWYSgKJHjxWdAEeE=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/pkg/ratelimit/bucket.go
+++ b/pkg/ratelimit/bucket.go
@@ -1,0 +1,110 @@
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// limiter wraps golang.org/x/time/rate.Limiter with our interface
+type limiter struct {
+	rateLimiter *rate.Limiter
+}
+
+func NewLimiter(ratePerSecond float64, burstSize int) (Limiter, error) {
+	if ratePerSecond <= 0 {
+		return nil, fmt.Errorf("%w: got %f", ErrRateMustBePositive, ratePerSecond)
+	}
+	if burstSize <= 0 {
+		return nil, fmt.Errorf("%w: got %d", ErrBurstSizeMustBePositive, burstSize)
+	}
+
+	rateLimiter := rate.NewLimiter(rate.Limit(ratePerSecond), burstSize)
+	return &limiter{rateLimiter: rateLimiter}, nil
+}
+
+// Wait blocks until the specified number of tokens can be consumed (implements Limiter interface)
+func (l *limiter) Wait(ctx context.Context, tokens int) error {
+	if tokens <= 0 {
+		return nil
+	}
+	return l.rateLimiter.WaitN(ctx, tokens)
+}
+
+// TryConsume attempts to consume tokens without blocking (implements Limiter interface)
+func (l *limiter) TryConsume(tokens int) bool {
+	if tokens <= 0 {
+		return true // Nothing to consume
+	}
+	return l.rateLimiter.AllowN(time.Now(), tokens)
+}
+
+// Tokens returns the current number of available tokens (implements Limiter interface)
+func (l *limiter) Tokens() float64 {
+	return l.rateLimiter.TokensAt(time.Now())
+}
+
+// SetRate updates the rate limit (implements Limiter interface)
+func (l *limiter) SetRate(ratePerSecond float64) error {
+	if ratePerSecond <= 0 {
+		return fmt.Errorf("%w: got %f", ErrRateMustBePositive, ratePerSecond)
+	}
+	l.rateLimiter.SetLimit(rate.Limit(ratePerSecond))
+	return nil
+}
+
+// TxMetrics represents transaction metrics for rate limiting
+type TxMetrics struct {
+	SizeBytes uint64 // Transaction size in bytes
+}
+
+// MultiLimiter wraps multiple types of rate limits
+type MultiLimiter struct {
+	tpsLimiter   Limiter
+	bytesLimiter Limiter
+	config       Config
+}
+
+// NewMultiLimiter creates a multi-metric rate limiter
+func NewMultiLimiter(config Config) (*MultiLimiter, error) {
+	ml := &MultiLimiter{config: config}
+
+	if config.TxPerSecond > 0 {
+		tpsLimiter, err := NewLimiter(config.TxPerSecond, config.GetTpsBurstSize())
+		if err != nil {
+			return nil, err
+		}
+		ml.tpsLimiter = tpsLimiter
+	}
+
+	if config.BytesPerSecond > 0 {
+		bytesLimiter, err := NewLimiter(config.GetBytesRate(), config.GetBytesBurstSize())
+		if err != nil {
+			return nil, err
+		}
+		ml.bytesLimiter = bytesLimiter
+	}
+
+	return ml, nil
+}
+
+// WaitForTransaction applies all configured rate limits for a transaction
+func (ml *MultiLimiter) WaitForTransaction(ctx context.Context, txMetrics TxMetrics) error {
+	// Apply TPS limiting (1 token per transaction)
+	if ml.tpsLimiter != nil {
+		if err := ml.tpsLimiter.Wait(ctx, 1); err != nil {
+			return fmt.Errorf("%w: %w", ErrTPSRateLimitExceeded, err)
+		}
+	}
+
+	// Apply Bytes limiting (N tokens based on actual tx size)
+	if ml.bytesLimiter != nil && txMetrics.SizeBytes > 0 {
+		if err := ml.bytesLimiter.Wait(ctx, int(txMetrics.SizeBytes)); err != nil {
+			return fmt.Errorf("%w: %w", ErrBytesRateLimitExceeded, err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/ratelimit/bucket.go
+++ b/pkg/ratelimit/bucket.go
@@ -2,6 +2,7 @@ package ratelimit
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -95,14 +96,30 @@ func (ml *MultiLimiter) WaitForTransaction(ctx context.Context, txMetrics TxMetr
 	// Apply TPS limiting (1 token per transaction)
 	if ml.tpsLimiter != nil {
 		if err := ml.tpsLimiter.Wait(ctx, 1); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return err
+			}
 			return fmt.Errorf("%w: %w", ErrTPSRateLimitExceeded, err)
 		}
 	}
 
 	// Apply Bytes limiting (N tokens based on actual tx size)
 	if ml.bytesLimiter != nil && txMetrics.SizeBytes > 0 {
-		if err := ml.bytesLimiter.Wait(ctx, int(txMetrics.SizeBytes)); err != nil {
-			return fmt.Errorf("%w: %w", ErrBytesRateLimitExceeded, err)
+		// Consume in chunks ≤ configured burst to avoid WaitN(n>burst) errors.
+		remaining := txMetrics.SizeBytes
+		chunk := ml.config.GetBytesBurstSize()
+		for remaining > 0 {
+			n := chunk
+			if remaining < uint64(chunk) {
+				n = int(remaining)
+			}
+			if err := ml.bytesLimiter.Wait(ctx, n); err != nil {
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					return err
+				}
+				return fmt.Errorf("%w: %w", ErrBytesRateLimitExceeded, err)
+			}
+			remaining -= uint64(n)
 		}
 	}
 

--- a/pkg/ratelimit/bucket.go
+++ b/pkg/ratelimit/bucket.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cosmos/cosmos-sdk/client"
 	"golang.org/x/time/rate"
 )
 
@@ -59,18 +60,24 @@ func (l *limiter) SetRate(ratePerSecond float64) error {
 // TxMetrics represents transaction metrics for rate limiting
 type TxMetrics struct {
 	SizeBytes uint64 // Transaction size in bytes
+	GasLimit  uint64 // Gas limit for the transaction
 }
 
 // MultiLimiter wraps multiple types of rate limits
 type MultiLimiter struct {
 	tpsLimiter   Limiter
 	bytesLimiter Limiter
+	gasLimiter   Limiter
+	txConfig     client.TxConfig // For decoding transactions to extract gas
 	config       Config
 }
 
 // NewMultiLimiter creates a multi-metric rate limiter
-func NewMultiLimiter(config Config) (*MultiLimiter, error) {
-	ml := &MultiLimiter{config: config}
+func NewMultiLimiter(config Config, txConfig client.TxConfig) (*MultiLimiter, error) {
+	ml := &MultiLimiter{
+		config:   config,
+		txConfig: txConfig,
+	}
 
 	if config.TxPerSecond > 0 {
 		tpsLimiter, err := NewLimiter(config.TxPerSecond, config.GetTpsBurstSize())
@@ -88,7 +95,32 @@ func NewMultiLimiter(config Config) (*MultiLimiter, error) {
 		ml.bytesLimiter = bytesLimiter
 	}
 
+	if config.GasPerSecond > 0 {
+		gasLimiter, err := NewLimiter(config.GetGasRate(), config.GetGasBurstSize())
+		if err != nil {
+			return nil, err
+		}
+		ml.gasLimiter = gasLimiter
+	}
+
 	return ml, nil
+}
+
+// WaitForTransactionBytes applies all configured rate limits for a transaction by decoding the bytes
+func (ml *MultiLimiter) WaitForTransactionBytes(ctx context.Context, txBytes []byte) error {
+	// Extract gas limit from transaction bytes
+	gasLimit, err := ExtractGasLimit(ml.txConfig, txBytes)
+	if err != nil {
+		// If we can't extract gas, just use 0 and continue with other limits
+		gasLimit = 0
+	}
+
+	metrics := TxMetrics{
+		SizeBytes: uint64(len(txBytes)),
+		GasLimit:  gasLimit,
+	}
+
+	return ml.WaitForTransaction(ctx, metrics)
 }
 
 // WaitForTransaction applies all configured rate limits for a transaction
@@ -118,6 +150,26 @@ func (ml *MultiLimiter) WaitForTransaction(ctx context.Context, txMetrics TxMetr
 					return err
 				}
 				return fmt.Errorf("%w: %w", ErrBytesRateLimitExceeded, err)
+			}
+			remaining -= uint64(n)
+		}
+	}
+
+	// Apply Gas limiting (N tokens based on actual gas limit)
+	if ml.gasLimiter != nil && txMetrics.GasLimit > 0 {
+		// Consume in chunks ≤ configured burst to avoid WaitN(n>burst) errors.
+		remaining := txMetrics.GasLimit
+		chunk := ml.config.GetGasBurstSize()
+		for remaining > 0 {
+			n := chunk
+			if remaining < uint64(chunk) {
+				n = int(remaining)
+			}
+			if err := ml.gasLimiter.Wait(ctx, n); err != nil {
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					return err
+				}
+				return fmt.Errorf("%w: %w", ErrGasRateLimitExceeded, err)
 			}
 			remaining -= uint64(n)
 		}

--- a/pkg/ratelimit/bucket_test.go
+++ b/pkg/ratelimit/bucket_test.go
@@ -1,0 +1,181 @@
+package ratelimit
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestLimiter(t *testing.T) {
+	t.Run("NewLimiter validates parameters", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			rate      float64
+			burstSize int
+			wantErr   bool
+		}{
+			{"valid parameters", 10.0, 20, false},
+			{"zero rate", 0, 20, true},
+			{"negative rate", -1.0, 20, true},
+			{"zero burst size", 10.0, 0, true},
+			{"negative burst size", 10.0, -1, true},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := NewLimiter(tt.rate, tt.burstSize)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("NewLimiter() error = %v, wantErr %v", err, tt.wantErr)
+				}
+
+				// Test specific error types
+				if tt.rate <= 0 && err != nil {
+					if !errors.Is(err, ErrRateMustBePositive) {
+						t.Errorf("Expected ErrRateMustBePositive, got %v", err)
+					}
+				}
+				if tt.burstSize <= 0 && tt.rate > 0 && err != nil {
+					if !errors.Is(err, ErrBurstSizeMustBePositive) {
+						t.Errorf("Expected ErrBurstSizeMustBePositive, got %v", err)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("Wait with context cancellation", func(t *testing.T) {
+		limiter, err := NewLimiter(1.0, 1) // 1 TPS, burst 1
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// First wait should succeed immediately
+		ctx := context.Background()
+		if err := limiter.Wait(ctx, 1); err != nil {
+			t.Errorf("First wait failed: %v", err)
+		}
+
+		// Second wait should block, test cancellation
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		if err := limiter.Wait(ctx, 1); err == nil {
+			t.Error("Expected error from cancelled context")
+		}
+	})
+
+	t.Run("SetRate updates rate", func(t *testing.T) {
+		limiter, err := NewLimiter(10.0, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Test valid rate update
+		if err := limiter.SetRate(20.0); err != nil {
+			t.Errorf("SetRate failed: %v", err)
+		}
+
+		// Test invalid rate
+		if err := limiter.SetRate(-1.0); err == nil {
+			t.Error("Expected error for negative rate")
+		}
+	})
+}
+
+func TestMultiLimiter(t *testing.T) {
+	t.Run("NewMultiLimiter with TPS only", func(t *testing.T) {
+		config := Config{
+			TxPerSecond: 10.0,
+			Burst: BurstConfig{
+				Size: 20,
+			},
+		}
+
+		limiter, err := NewMultiLimiter(config)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if limiter == nil {
+			t.Error("Expected non-nil limiter")
+		}
+
+		// Test TPS limiting
+		ctx := context.Background()
+		txMetrics := TxMetrics{} // Empty metrics for TPS-only
+
+		if err := limiter.WaitForTransaction(ctx, txMetrics); err != nil {
+			t.Errorf("WaitForTransaction failed: %v", err)
+		}
+	})
+
+	t.Run("NewMultiLimiter with TPS and bytes limits", func(t *testing.T) {
+		config := Config{
+			TxPerSecond:    10.0,
+			BytesPerSecond: 50000,
+			// Let burst size auto-calculate (default multiplier applied)
+		}
+
+		limiter, err := NewMultiLimiter(config)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if limiter == nil {
+			t.Error("Expected non-nil limiter")
+		}
+
+		// Test with real transaction metrics
+		ctx := context.Background()
+		txMetrics := TxMetrics{
+			SizeBytes: 150,
+		}
+
+		if err := limiter.WaitForTransaction(ctx, txMetrics); err != nil {
+			t.Errorf("WaitForTransaction with metrics failed: %v", err)
+		}
+	})
+
+	t.Run("NewMultiLimiter with no limits", func(t *testing.T) {
+		config := Config{} // No limits configured
+
+		limiter, err := NewMultiLimiter(config)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Should work without any limiting
+		ctx := context.Background()
+		txMetrics := TxMetrics{}
+
+		if err := limiter.WaitForTransaction(ctx, txMetrics); err != nil {
+			t.Errorf("WaitForTransaction with no limits failed: %v", err)
+		}
+	})
+}
+
+func TestPerformanceBasic(t *testing.T) {
+	// Just a basic smoke test to ensure our wrapper doesn't add significant overhead
+	t.Run("Limiter performance", func(t *testing.T) {
+		limiter, err := NewLimiter(1000.0, 1000) // High rate for testing
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		start := time.Now()
+		ctx := context.Background()
+
+		// Try to consume 100 tokens quickly
+		for i := 0; i < 100; i++ {
+			if err := limiter.Wait(ctx, 1); err != nil {
+				t.Fatalf("Wait failed at iteration %d: %v", i, err)
+			}
+		}
+
+		elapsed := time.Since(start)
+		if elapsed > 500*time.Millisecond {
+			t.Errorf("Performance test took too long: %v", elapsed)
+		}
+	})
+}

--- a/pkg/ratelimit/bucket_test.go
+++ b/pkg/ratelimit/bucket_test.go
@@ -5,6 +5,14 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"cosmossdk.io/math"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/std"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/tx"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
 func TestLimiter(t *testing.T) {
@@ -92,7 +100,7 @@ func TestMultiLimiter(t *testing.T) {
 			},
 		}
 
-		limiter, err := NewMultiLimiter(config)
+		limiter, err := NewMultiLimiter(config, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -117,7 +125,7 @@ func TestMultiLimiter(t *testing.T) {
 			// Let burst size auto-calculate (default multiplier applied)
 		}
 
-		limiter, err := NewMultiLimiter(config)
+		limiter, err := NewMultiLimiter(config, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -140,7 +148,7 @@ func TestMultiLimiter(t *testing.T) {
 	t.Run("NewMultiLimiter with no limits", func(t *testing.T) {
 		config := Config{} // No limits configured
 
-		limiter, err := NewMultiLimiter(config)
+		limiter, err := NewMultiLimiter(config, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -176,6 +184,94 @@ func TestPerformanceBasic(t *testing.T) {
 		elapsed := time.Since(start)
 		if elapsed > 500*time.Millisecond {
 			t.Errorf("Performance test took too long: %v", elapsed)
+		}
+	})
+}
+
+func TestMultiLimiter_GasLimiting(t *testing.T) {
+	// Setup a basic tx config for testing
+	interfaceRegistry := types.NewInterfaceRegistry()
+	std.RegisterInterfaces(interfaceRegistry)
+	banktypes.RegisterInterfaces(interfaceRegistry)
+
+	marshaler := codec.NewProtoCodec(interfaceRegistry)
+	txConfig := tx.NewTxConfig(marshaler, tx.DefaultSignModes)
+
+	config := Config{
+		GasPerSecond: 100, // Allow 100 gas units per second
+		Burst: BurstConfig{
+			Size: 50, // Burst of 50 gas units
+		},
+	}
+
+	limiter, err := NewMultiLimiter(config, txConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("Gas limiting with transaction bytes", func(t *testing.T) {
+		// Create a transaction with known gas limit
+		txBuilder := txConfig.NewTxBuilder()
+
+		msg := banktypes.NewMsgSend(
+			sdk.AccAddress("sender"),
+			sdk.AccAddress("recipient"),
+			sdk.NewCoins(sdk.NewCoin("stake", math.NewInt(100))),
+		)
+
+		txBuilder.SetMsgs(msg)
+		txBuilder.SetGasLimit(30) // Set gas limit to 30
+		txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("stake", math.NewInt(10))))
+
+		// Encode the transaction
+		txBytes, err := txConfig.TxEncoder()(txBuilder.GetTx())
+		if err != nil {
+			t.Fatalf("Failed to encode transaction: %v", err)
+		}
+
+		ctx := context.Background()
+
+		// First transaction should succeed (30 gas units)
+		start := time.Now()
+		if err := limiter.WaitForTransactionBytes(ctx, txBytes); err != nil {
+			t.Errorf("First transaction failed: %v", err)
+		}
+
+		// Second transaction should also succeed (total 60 gas units)
+		if err := limiter.WaitForTransactionBytes(ctx, txBytes); err != nil {
+			t.Errorf("Second transaction failed: %v", err)
+		}
+
+		// Third transaction should be rate limited (would be 90 gas units)
+		if err := limiter.WaitForTransactionBytes(ctx, txBytes); err != nil {
+			t.Errorf("Third transaction failed: %v", err)
+		}
+
+		elapsed := time.Since(start)
+		// Should take some time due to rate limiting
+		if elapsed < 100*time.Millisecond {
+			t.Errorf("Expected some delay due to rate limiting, but took only %v", elapsed)
+		}
+	})
+
+	t.Run("Gas limiting with manual metrics", func(t *testing.T) {
+		ctx := context.Background()
+
+		// High gas transaction should be rate limited
+		highGasMetrics := TxMetrics{
+			SizeBytes: 1000,
+			GasLimit:  200, // Exceeds our 100 gas/sec limit
+		}
+
+		start := time.Now()
+		if err := limiter.WaitForTransaction(ctx, highGasMetrics); err != nil {
+			t.Errorf("High gas transaction failed: %v", err)
+		}
+		elapsed := time.Since(start)
+
+		// Should take at least 1 second due to rate limiting (200 gas at 100 gas/sec)
+		if elapsed < 1*time.Second {
+			t.Errorf("Expected significant delay for high gas transaction, but took only %v", elapsed)
 		}
 	})
 }

--- a/pkg/ratelimit/config.go
+++ b/pkg/ratelimit/config.go
@@ -1,0 +1,84 @@
+package ratelimit
+
+// DefaultBurstMultiplier defines how many seconds worth of tokens to allow,
+// ensuring burst respects the specified rate limit without exceeding it.
+const DefaultBurstMultiplier = 1
+
+// Rate limiting configuration
+type Config struct {
+	// TxPerSecond limits the number of transactions per second
+	TxPerSecond float64 `yaml:"tx_per_second,omitempty" json:"tx_per_second,omitempty"`
+
+	// BytesPerSecond limits the transaction bytes processed per second
+	BytesPerSecond uint64 `yaml:"bytes_per_second,omitempty" json:"bytes_per_second,omitempty"`
+
+	// Burst configuration
+	Burst BurstConfig `yaml:"burst" json:"burst"`
+}
+
+// BurstConfig defines burst allowance settings
+type BurstConfig struct {
+	// Size is the maximum number of tokens that can be consumed in a burst
+	// For TxPerSecond, this is the max number of transactions
+	// For BytesPerSecond, this is the max bytes
+	// If Size > 0, burst is automatically enabled
+	Size int `yaml:"size" json:"size"`
+}
+
+// IsEnabled returns true if any rate limiting is configured
+func (c *Config) IsEnabled() bool {
+	return c.TxPerSecond > 0 || c.BytesPerSecond > 0
+}
+
+// Validate checks if the configuration is valid
+func (c *Config) Validate() error {
+	if !c.IsEnabled() {
+		return nil
+	}
+
+	if c.TxPerSecond == 0 && c.BytesPerSecond == 0 {
+		return ErrAtLeastOneRateLimitRequired
+	}
+
+	if c.TxPerSecond < 0 {
+		return ErrTxPerSecondMustBePositive
+	}
+
+	return nil
+}
+
+// HasTxLimit returns true if transaction rate limiting is configured
+func (c *Config) HasTxLimit() bool {
+	return c.IsEnabled() && c.TxPerSecond > 0
+}
+
+// HasBytesLimit returns true if bytes rate limiting is configured
+func (c *Config) HasBytesLimit() bool {
+	return c.IsEnabled() && c.BytesPerSecond > 0
+}
+
+// GetTxRate returns the transaction rate
+func (c *Config) GetTxRate() float64 {
+	return c.TxPerSecond
+}
+
+// GetBytesRate returns the bytes rate
+func (c *Config) GetBytesRate() float64 {
+	return float64(c.BytesPerSecond)
+}
+
+// GetTpsBurstSize returns burst size specifically for TPS limiting
+func (c *Config) GetTpsBurstSize() int {
+	if c.Burst.Size > 0 {
+		return c.Burst.Size
+	}
+	return int(c.TxPerSecond * DefaultBurstMultiplier)
+}
+
+// GetBytesBurstSize returns burst size specifically for bytes limiting
+func (c *Config) GetBytesBurstSize() int {
+	if c.Burst.Size > 0 {
+		return c.Burst.Size
+	}
+	return int(c.BytesPerSecond * DefaultBurstMultiplier)
+}

--- a/pkg/ratelimit/config.go
+++ b/pkg/ratelimit/config.go
@@ -14,6 +14,9 @@ type Config struct {
 	// BytesPerSecond limits the transaction bytes processed per second
 	BytesPerSecond uint64 `yaml:"bytes_per_second,omitempty" json:"bytes_per_second,omitempty"`
 
+	// GasPerSecond limits the gas units processed per second
+	GasPerSecond uint64 `yaml:"gas_per_second,omitempty" json:"gas_per_second,omitempty"`
+
 	// Burst configuration
 	Burst BurstConfig `yaml:"burst" json:"burst"`
 }
@@ -29,7 +32,7 @@ type BurstConfig struct {
 
 // IsEnabled returns true if any rate limiting is configured
 func (c *Config) IsEnabled() bool {
-	return c.TxPerSecond > 0 || c.BytesPerSecond > 0
+	return c.TxPerSecond > 0 || c.BytesPerSecond > 0 || c.GasPerSecond > 0
 }
 
 // Validate checks if the configuration is valid
@@ -38,7 +41,7 @@ func (c *Config) Validate() error {
 		return nil
 	}
 
-	if c.TxPerSecond == 0 && c.BytesPerSecond == 0 {
+	if c.TxPerSecond == 0 && c.BytesPerSecond == 0 && c.GasPerSecond == 0 {
 		return ErrAtLeastOneRateLimitRequired
 	}
 
@@ -59,6 +62,11 @@ func (c *Config) HasBytesLimit() bool {
 	return c.IsEnabled() && c.BytesPerSecond > 0
 }
 
+// HasGasLimit returns true if gas rate limiting is configured
+func (c *Config) HasGasLimit() bool {
+	return c.IsEnabled() && c.GasPerSecond > 0
+}
+
 // GetTxRate returns the transaction rate
 func (c *Config) GetTxRate() float64 {
 	return c.TxPerSecond
@@ -67,6 +75,11 @@ func (c *Config) GetTxRate() float64 {
 // GetBytesRate returns the bytes rate
 func (c *Config) GetBytesRate() float64 {
 	return float64(c.BytesPerSecond)
+}
+
+// GetGasRate returns the gas rate
+func (c *Config) GetGasRate() float64 {
+	return float64(c.GasPerSecond)
 }
 
 // GetTpsBurstSize returns burst size specifically for TPS limiting
@@ -88,6 +101,23 @@ func (c *Config) GetBytesBurstSize() int {
 	}
 	// Saturating cast to int
 	b := c.BytesPerSecond * uint64(DefaultBurstMultiplier)
+	maxInt := int(^uint(0) >> 1)
+	if b == 0 {
+		return 1
+	}
+	if b > uint64(maxInt) {
+		return maxInt
+	}
+	return int(b)
+}
+
+// GetGasBurstSize returns burst size specifically for gas limiting
+func (c *Config) GetGasBurstSize() int {
+	if c.Burst.Size > 0 {
+		return c.Burst.Size
+	}
+	// Saturating cast to int
+	b := c.GasPerSecond * uint64(DefaultBurstMultiplier)
 	maxInt := int(^uint(0) >> 1)
 	if b == 0 {
 		return 1

--- a/pkg/ratelimit/config.go
+++ b/pkg/ratelimit/config.go
@@ -1,5 +1,7 @@
 package ratelimit
 
+import "math"
+
 // DefaultBurstMultiplier defines how many seconds worth of tokens to allow,
 // ensuring burst respects the specified rate limit without exceeding it.
 const DefaultBurstMultiplier = 1
@@ -72,7 +74,11 @@ func (c *Config) GetTpsBurstSize() int {
 	if c.Burst.Size > 0 {
 		return c.Burst.Size
 	}
-	return int(c.TxPerSecond * DefaultBurstMultiplier)
+	v := int(math.Ceil(c.TxPerSecond * float64(DefaultBurstMultiplier)))
+	if v < 1 {
+		return 1
+	}
+	return v
 }
 
 // GetBytesBurstSize returns burst size specifically for bytes limiting
@@ -80,5 +86,14 @@ func (c *Config) GetBytesBurstSize() int {
 	if c.Burst.Size > 0 {
 		return c.Burst.Size
 	}
-	return int(c.BytesPerSecond * DefaultBurstMultiplier)
+	// Saturating cast to int
+	b := c.BytesPerSecond * uint64(DefaultBurstMultiplier)
+	maxInt := int(^uint(0) >> 1)
+	if b == 0 {
+		return 1
+	}
+	if b > uint64(maxInt) {
+		return maxInt
+	}
+	return int(b)
 }

--- a/pkg/ratelimit/doc.go
+++ b/pkg/ratelimit/doc.go
@@ -1,0 +1,25 @@
+// Package ratelimit provides transaction rate limiting using golang.org/x/time/rate.
+//
+// Supports TPS and bandwidth limiting with Token Bucket algorithm for controlled bursts.
+//
+// Basic Usage:
+//
+//	config := ratelimit.Config{
+//		TxPerSecond:    100,   // 100 TPS limit
+//		BytesPerSecond: 50000, // 50KB/sec limit
+//	}
+//
+//	limiter, err := ratelimit.NewMultiLimiter(config)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//
+//	// For each transaction:
+//	txMetrics := ratelimit.TxMetrics{
+//		SizeBytes: uint64(len(txBytes)),
+//	}
+//	err = limiter.WaitForTransaction(ctx, txMetrics)
+//
+// Custom burst sizes can be set via Config.Burst.Size.
+// Default burst allows 1x the rate (e.g., 100 TPS = 100 burst).
+package ratelimit

--- a/pkg/ratelimit/errors.go
+++ b/pkg/ratelimit/errors.go
@@ -1,0 +1,27 @@
+package ratelimit
+
+import "errors"
+
+// Sentinel errors for rate limiting operations
+var (
+	// ErrRateMustBePositive indicates an invalid rate parameter
+	ErrRateMustBePositive = errors.New("rate must be positive")
+
+	// ErrBurstSizeMustBePositive indicates an invalid burst size parameter
+	ErrBurstSizeMustBePositive = errors.New("burst size must be positive")
+
+	// ErrAtLeastOneRateLimitRequired indicates no rate limits were configured
+	ErrAtLeastOneRateLimitRequired = errors.New("at least one rate limit must be configured when enabled")
+
+	// ErrTxPerSecondMustBePositive indicates an invalid TPS rate
+	ErrTxPerSecondMustBePositive = errors.New("tx_per_second must be positive")
+
+	// ErrBytesPerSecondMustBePositive indicates an invalid bytes rate
+	ErrBytesPerSecondMustBePositive = errors.New("bytes_per_second must be positive")
+
+	// ErrTPSRateLimitExceeded indicates TPS rate limit was hit
+	ErrTPSRateLimitExceeded = errors.New("TPS rate limit exceeded")
+
+	// ErrBytesRateLimitExceeded indicates bytes rate limit was hit
+	ErrBytesRateLimitExceeded = errors.New("bytes rate limit exceeded")
+)

--- a/pkg/ratelimit/errors.go
+++ b/pkg/ratelimit/errors.go
@@ -24,4 +24,7 @@ var (
 
 	// ErrBytesRateLimitExceeded indicates bytes rate limit was hit
 	ErrBytesRateLimitExceeded = errors.New("bytes rate limit exceeded")
+
+	// ErrGasRateLimitExceeded indicates gas rate limit was hit
+	ErrGasRateLimitExceeded = errors.New("gas rate limit exceeded")
 )

--- a/pkg/ratelimit/gas.go
+++ b/pkg/ratelimit/gas.go
@@ -9,6 +9,10 @@ import (
 // This works for both regular Cosmos transactions and Ethereum transactions
 // wrapped in MsgEthereumTx since they both become Cosmos SDK transactions.
 func ExtractGasLimit(txConfig client.TxConfig, txBytes []byte) (uint64, error) {
+	if txConfig == nil {
+		// No decoder provided; treat as unknown gas (0).
+		return 0, nil
+	}
 	tx, err := txConfig.TxDecoder()(txBytes)
 	if err != nil {
 		return 0, err

--- a/pkg/ratelimit/gas.go
+++ b/pkg/ratelimit/gas.go
@@ -1,0 +1,25 @@
+package ratelimit
+
+import (
+	"github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// ExtractGasLimit extracts gas limit from Cosmos SDK transaction bytes.
+// This works for both regular Cosmos transactions and Ethereum transactions
+// wrapped in MsgEthereumTx since they both become Cosmos SDK transactions.
+func ExtractGasLimit(txConfig client.TxConfig, txBytes []byte) (uint64, error) {
+	tx, err := txConfig.TxDecoder()(txBytes)
+	if err != nil {
+		return 0, err
+	}
+
+	// Cast to FeeTx to access gas information
+	feeTx, ok := tx.(sdk.FeeTx)
+	if !ok {
+		// If transaction doesn't implement FeeTx, return 0
+		return 0, nil
+	}
+
+	return feeTx.GetGas(), nil
+}

--- a/pkg/ratelimit/gas_test.go
+++ b/pkg/ratelimit/gas_test.go
@@ -102,3 +102,16 @@ func TestExtractGasLimit_InvalidTransaction(t *testing.T) {
 		t.Errorf("Expected 0 gas for invalid transaction, got %d", gas)
 	}
 }
+
+func TestExtractGasLimit_NilTxConfig(t *testing.T) {
+	// Test with nil txConfig should not panic and return 0 gas
+	validBytes := []byte("some transaction bytes")
+
+	gas, err := ExtractGasLimit(nil, validBytes)
+	if err != nil {
+		t.Errorf("Expected no error for nil txConfig, got: %v", err)
+	}
+	if gas != 0 {
+		t.Errorf("Expected 0 gas for nil txConfig, got %d", gas)
+	}
+}

--- a/pkg/ratelimit/gas_test.go
+++ b/pkg/ratelimit/gas_test.go
@@ -1,0 +1,104 @@
+package ratelimit
+
+import (
+	"testing"
+
+	"cosmossdk.io/math"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/std"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/tx"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+)
+
+func TestExtractGasLimit(t *testing.T) {
+	// Setup a basic tx config for testing
+	interfaceRegistry := types.NewInterfaceRegistry()
+	std.RegisterInterfaces(interfaceRegistry)
+	banktypes.RegisterInterfaces(interfaceRegistry)
+
+	marshaler := codec.NewProtoCodec(interfaceRegistry)
+	txConfig := tx.NewTxConfig(marshaler, tx.DefaultSignModes)
+
+	tests := []struct {
+		name        string
+		gasLimit    uint64
+		expectError bool
+		expectedGas uint64
+	}{
+		{
+			name:        "normal gas limit",
+			gasLimit:    100000,
+			expectError: false,
+			expectedGas: 100000,
+		},
+		{
+			name:        "high gas limit",
+			gasLimit:    10000000,
+			expectError: false,
+			expectedGas: 10000000,
+		},
+		{
+			name:        "zero gas limit",
+			gasLimit:    0,
+			expectError: false,
+			expectedGas: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a simple bank send transaction for testing
+			txBuilder := txConfig.NewTxBuilder()
+
+			msg := banktypes.NewMsgSend(
+				sdk.AccAddress("sender"),
+				sdk.AccAddress("recipient"),
+				sdk.NewCoins(sdk.NewCoin("stake", math.NewInt(100))),
+			)
+
+			txBuilder.SetMsgs(msg)
+			txBuilder.SetGasLimit(tt.gasLimit)
+			txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("stake", math.NewInt(10))))
+
+			// Encode the transaction
+			txBytes, err := txConfig.TxEncoder()(txBuilder.GetTx())
+			if err != nil {
+				t.Fatalf("Failed to encode transaction: %v", err)
+			}
+
+			// Test gas extraction
+			extractedGas, err := ExtractGasLimit(txConfig, txBytes)
+
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if extractedGas != tt.expectedGas {
+				t.Errorf("Expected gas %d, got %d", tt.expectedGas, extractedGas)
+			}
+		})
+	}
+}
+
+func TestExtractGasLimit_InvalidTransaction(t *testing.T) {
+	interfaceRegistry := types.NewInterfaceRegistry()
+	std.RegisterInterfaces(interfaceRegistry)
+
+	marshaler := codec.NewProtoCodec(interfaceRegistry)
+	txConfig := tx.NewTxConfig(marshaler, tx.DefaultSignModes)
+
+	// Test with invalid transaction bytes
+	invalidBytes := []byte("invalid transaction data")
+
+	gas, err := ExtractGasLimit(txConfig, invalidBytes)
+	if err == nil {
+		t.Errorf("Expected error for invalid transaction bytes")
+	}
+	if gas != 0 {
+		t.Errorf("Expected 0 gas for invalid transaction, got %d", gas)
+	}
+}

--- a/pkg/ratelimit/limiter.go
+++ b/pkg/ratelimit/limiter.go
@@ -1,0 +1,26 @@
+package ratelimit
+
+import (
+	"context"
+)
+
+// BroadcastFunc represents a generic broadcast function signature
+type BroadcastFunc func(ctx context.Context, txBytes []byte) (string, error)
+
+// Limiter represents a rate limiter using the Token Bucket algorithm.
+// This allows controlled bursts while maintaining an average rate over time.
+type Limiter interface {
+	// Wait blocks until the limiter permits the consumption of the specified number of tokens
+	// Returns an error if the context is cancelled before permission is granted
+	Wait(ctx context.Context, tokens int) error
+
+	// TryConsume attempts to consume the specified number of tokens without blocking
+	// Returns true if tokens were successfully consumed, false otherwise
+	TryConsume(tokens int) bool
+
+	// Tokens returns the current number of available tokens
+	Tokens() float64
+
+	// SetRate updates the rate limit (tokens per second)
+	SetRate(rate float64) error
+}

--- a/stresser.go
+++ b/stresser.go
@@ -381,7 +381,12 @@ func Stress(
 			return baseClient.Broadcast(ctx, txBytes, config.AwaitTxConfirmation)
 		}
 	} else if config.RateLimit.IsEnabled() {
-		logger.Info("✅ Rate limiter enabled")
+		logger.WithFields(log.Fields{
+			"tps_limit":        config.RateLimit.TxPerSecond,
+			"bytes_per_second": config.RateLimit.BytesPerSecond,
+			"gas_per_second":   config.RateLimit.GasPerSecond,
+			"burst_size":       config.RateLimit.Burst.Size,
+		}).Info("✅ Rate limiter enabled")
 	}
 
 	if err := parallel.Run(ctx, func(ctx context.Context, spawn parallel.SpawnFn) error {
@@ -465,7 +470,13 @@ func StressReplay(
 	}
 
 	if config.RateLimit.IsEnabled() {
-		logger.Info("✅ Rate limiter enabled for replay")
+		logger.WithFields(log.Fields{
+			"tps_limit":        config.RateLimit.TxPerSecond,
+			"bytes_per_second": config.RateLimit.BytesPerSecond,
+			"gas_per_second":   config.RateLimit.GasPerSecond,
+			"burst_size":       config.RateLimit.Burst.Size,
+		}).Info("✅ Rate limiter enabled for replay")
+
 	}
 
 	// Create client for gas fuzzing (separate from broadcast function)
@@ -731,27 +742,24 @@ func createAndBroadcastInitialTxs(
 
 // buildBroadcastFunc creates a broadcast function with optional rate limiting
 func buildBroadcastClient(config StressConfig) (ratelimit.BroadcastFunc, error) {
+	// Create shared client for all accounts
+	baseClient := chain.NewClient(config.ChainID, config.NodeAddress, config.GRPCAddress)
+
 	// Create rate limiter if enabled
 	var rateLimiter *ratelimit.MultiLimiter
 	if config.RateLimit.IsEnabled() {
-		limiter, err := ratelimit.NewMultiLimiter(config.RateLimit)
+		limiter, err := ratelimit.NewMultiLimiter(config.RateLimit, baseClient.TxConfig())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create rate limiter: %w", err)
 		}
 		rateLimiter = limiter
 	}
 
-	// Create shared client for all accounts
-	baseClient := chain.NewClient(config.ChainID, config.NodeAddress, config.GRPCAddress)
-
 	// Return broadcast function with rate limiting
 	return func(ctx context.Context, txBytes []byte) (string, error) {
 		// Apply rate limiting if enabled
 		if rateLimiter != nil {
-			txMetrics := ratelimit.TxMetrics{
-				SizeBytes: uint64(len(txBytes)),
-			}
-			if err := rateLimiter.WaitForTransaction(ctx, txMetrics); err != nil {
+			if err := rateLimiter.WaitForTransactionBytes(ctx, txBytes); err != nil {
 				return "", fmt.Errorf("rate limit wait failed: %w", err)
 			}
 		}

--- a/stresser.go
+++ b/stresser.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/InjectiveLabs/chain-stresser/v2/chain"
 	"github.com/InjectiveLabs/chain-stresser/v2/payload"
+	"github.com/InjectiveLabs/chain-stresser/v2/pkg/ratelimit"
 	"github.com/InjectiveLabs/chain-stresser/v2/replay"
 )
 
@@ -49,6 +50,9 @@ type StressConfig struct {
 
 	// GasFuzzing configuration for gas value fuzzing during replay
 	GasFuzzing replay.GasFuzzingConfig
+
+	// RateLimit configuration for controlling transaction throughput
+	RateLimit ratelimit.Config
 }
 
 // maxParallelInitialTxsBroadcasts is the maximum number of initial txs to broadcast in parallel.
@@ -59,8 +63,7 @@ const maxParallelInitialTxsBroadcasts = 8
 func handleFallbackBroadcast(
 	ctx context.Context,
 	originalTxBytes []byte,
-	accountClient chain.Client,
-	config StressConfig,
+	broadcastFunc ratelimit.BroadcastFunc,
 	fuzzedError string,
 	logger log.Logger,
 ) (txHash string, err error, wasSuccessful bool) {
@@ -68,7 +71,7 @@ func handleFallbackBroadcast(
 		"fuzzed_error": fuzzedError,
 	}).Debug("🔄 Fuzzed transaction failed with out of gas error, retrying with original")
 
-	fallbackTxHash, fallbackErr := accountClient.Broadcast(ctx, originalTxBytes, config.AwaitTxConfirmation)
+	fallbackTxHash, fallbackErr := broadcastFunc(ctx, originalTxBytes)
 	if fallbackErr != nil {
 		logger.WithFields(log.Fields{
 			"fuzzed_error":   fuzzedError,
@@ -367,6 +370,20 @@ func Stress(
 	startTs = time.Now()
 
 	logger.Info("Broadcasting transactions 🚀")
+
+	// Create broadcast function with optional rate limiting
+	rateLimitedBroadcast, err := buildBroadcastClient(config)
+	if err != nil {
+		logger.WithError(err).Error("Failed to create broadcast function, falling back to unthrottled")
+		// Create fallback broadcast function without rate limiting
+		baseClient := chain.NewClient(config.ChainID, config.NodeAddress, config.GRPCAddress)
+		rateLimitedBroadcast = func(ctx context.Context, txBytes []byte) (string, error) {
+			return baseClient.Broadcast(ctx, txBytes, config.AwaitTxConfirmation)
+		}
+	} else if config.RateLimit.IsEnabled() {
+		logger.Info("✅ Rate limiter enabled")
+	}
+
 	if err := parallel.Run(ctx, func(ctx context.Context, spawn parallel.SpawnFn) error {
 		spawn("accounts", parallel.Exit, func(ctx context.Context) error {
 			return parallel.Run(ctx, func(ctx context.Context, spawn parallel.SpawnFn) error {
@@ -375,7 +392,6 @@ func Stress(
 					accountIdx := accountIdx
 
 					initialSequence := initialAccountSequences[accountIdx]
-					accountClient := chain.NewClient(config.ChainID, config.NodeAddress, config.GRPCAddress)
 
 					spawn(fmt.Sprintf("account-%d", accountIdx), parallel.Continue, func(ctx context.Context) error {
 						defer catcher.Catch(
@@ -386,7 +402,7 @@ func Stress(
 						for txIndex := 0; txIndex < config.NumOfTransactions; {
 							tx := accountTxs[txIndex]
 
-							txHash, err := accountClient.Broadcast(ctx, tx, config.AwaitTxConfirmation)
+							txHash, err := rateLimitedBroadcast(ctx, tx)
 							if err != nil {
 								if expectedAccSeq, ok := chain.IsSequenceError(err); ok {
 									logger.WithError(err).WithFields(log.Fields{
@@ -442,6 +458,17 @@ func StressReplay(
 ) error {
 	logger := log.WithField("bench", txProvider.Name())
 
+	// Create broadcast function with optional rate limiting
+	broadcastFunc, err := buildBroadcastClient(config)
+	if err != nil {
+		return fmt.Errorf("failed to create broadcast function: %w", err)
+	}
+
+	if config.RateLimit.IsEnabled() {
+		logger.Info("✅ Rate limiter enabled for replay")
+	}
+
+	// Create client for gas fuzzing (separate from broadcast function)
 	accountClient := chain.NewClient(config.ChainID, config.NodeAddress, config.GRPCAddress)
 	broadcastTxPace := pace.New("sent tx", 10*time.Second, NewPaceReporter(logger))
 
@@ -503,7 +530,7 @@ func StressReplay(
 					}
 				}
 
-				txHash, err := accountClient.Broadcast(ctx, txBytes, config.AwaitTxConfirmation)
+				txHash, err := broadcastFunc(ctx, txBytes)
 
 				// Handle broadcast result
 				if err != nil {
@@ -514,7 +541,7 @@ func StressReplay(
 					// Try fallback for fuzzed transactions that fail with insufficient fee
 					if wasFuzzed && strings.Contains(errMsg, "out of gas") {
 						fallbackHash, fallbackErr, fallbackSuccess := handleFallbackBroadcast(
-							ctx, originalTxBytes, accountClient, config, errMsg, logger)
+							ctx, originalTxBytes, broadcastFunc, errMsg, logger)
 
 						if fallbackSuccess {
 							successCount++
@@ -536,12 +563,12 @@ func StressReplay(
 			}
 
 			logFields := log.Fields{
-				"total":           len(txBatch),
-				"success":         successCount,
-				"timeout_errors":  timeoutErrors,
-				"sequence_errors": sequenceErrors,
-				"out_of_gas_errors":  outOfGasErrors,
-				"other_errors":    otherErrors,
+				"total":             len(txBatch),
+				"success":           successCount,
+				"timeout_errors":    timeoutErrors,
+				"sequence_errors":   sequenceErrors,
+				"out_of_gas_errors": outOfGasErrors,
+				"other_errors":      otherErrors,
 			}
 
 			if gasFuzzer != nil {
@@ -700,4 +727,34 @@ func createAndBroadcastInitialTxs(
 	defer pool.StopWait()
 
 	return nil
+}
+
+// buildBroadcastFunc creates a broadcast function with optional rate limiting
+func buildBroadcastClient(config StressConfig) (ratelimit.BroadcastFunc, error) {
+	// Create rate limiter if enabled
+	var rateLimiter *ratelimit.MultiLimiter
+	if config.RateLimit.IsEnabled() {
+		limiter, err := ratelimit.NewMultiLimiter(config.RateLimit)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create rate limiter: %w", err)
+		}
+		rateLimiter = limiter
+	}
+
+	// Create shared client for all accounts
+	baseClient := chain.NewClient(config.ChainID, config.NodeAddress, config.GRPCAddress)
+
+	// Return broadcast function with rate limiting
+	return func(ctx context.Context, txBytes []byte) (string, error) {
+		// Apply rate limiting if enabled
+		if rateLimiter != nil {
+			txMetrics := ratelimit.TxMetrics{
+				SizeBytes: uint64(len(txBytes)),
+			}
+			if err := rateLimiter.WaitForTransaction(ctx, txMetrics); err != nil {
+				return "", fmt.Errorf("rate limit wait failed: %w", err)
+			}
+		}
+		return baseClient.Broadcast(ctx, txBytes, config.AwaitTxConfirmation)
+	}, nil
 }


### PR DESCRIPTION
This PR adds ratelimit pkg that implements TPS, bytes and gas limiting. The pkg is fully client agnostic, reusable, and easily extendable with other limits.

Checkout README for usage examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Optional multi-metric rate limiting for broadcasts (TPS, bytes/sec, gas/sec) with configurable burst sizing; applied in normal and replay modes.
  - New CLI flags: --rate-tps, --rate-bytes, --rate-gas, --rate-burst-size (defaults disable limits).
  - Per-transaction gas extraction to support gas-based limiting.

- **Documentation**
  - README updated with Rate Limiting section, examples, and combined-limit behavior.

- **Tests**
  - New tests covering limiter behavior, gas extraction, validation, and basic performance.

- **Chores**
  - Removed an unused dependency from module file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->