### PR TITLE
feat: replay txs from file

### DIFF
--- a/cmd/chain-stresser/main.go
+++ b/cmd/chain-stresser/main.go
@@ -528,10 +528,16 @@ func main() {
 		Use:   "tx-replay",
 		Short: "Run stresstest with state replay transactions.",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if replayCfg.CometRPC == "" {
-				return errors.New("--sniffer-rpc is required for remote sniffing.")
+			if replayCfg.CometRPC == "" && replayCfg.FromFile == "" {
+				return errors.New("--sniffer-rpc or --from-file is required to replay.")
 			}
-			if replayCfg.StartHeight == 0 {
+			if replayCfg.FromFile != "" && replayCfg.ToFile != "" {
+				return errors.New("Both --from-file and --to-file shouldn't be set at the same time.")
+			}
+			if replayCfg.FromFile != "" && (replayCfg.StartHeight != 0 || replayCfg.EndHeight != 0) {
+				return errors.New("Shouldn't set block start or end heights when replaying from file")
+			}
+			if replayCfg.StartHeight == 0 && replayCfg.FromFile == "" {
 				return errors.New("--sniffer-start-height is required for remote sniffing.")
 			}
 
@@ -545,18 +551,13 @@ func main() {
 				log.DefaultLogger.SetLevel(log.DebugLevel)
 			}
 
-			queryClient := chain.NewClient(
-				stressCfg.ChainID,
-				stressCfg.NodeAddress,
-				stressCfg.GRPCAddress,
-			)
-			var txnsReplayProvider payload.TxProvider
-
 			sniffer, err := replay.NewSniffer(
 				&replay.TxReplayConfig{
 					CometRPC:    replayCfg.CometRPC,
 					StartHeight: int64(replayCfg.StartHeight),
 					EndHeight:   replayCfg.EndHeight,
+					FromFile:    replayCfg.FromFile,
+					ToFile:      replayCfg.ToFile,
 				},
 				rootCtx,
 			)
@@ -568,7 +569,17 @@ func main() {
 				sniffer.Start()
 			}()
 
-			txnsReplayProvider, err = payload.NewTxnsReplayStressProvider(
+			if replayCfg.ToFile != "" { // we just dumping txs, no replay needed
+				<-sniffer.Done()
+				return nil
+			}
+
+			queryClient := chain.NewClient(
+				stressCfg.ChainID,
+				stressCfg.NodeAddress,
+				stressCfg.GRPCAddress,
+			)
+			txnsReplayProvider, err := payload.NewTxnsReplayStressProvider(
 				queryClient,
 				sniffer.Blocks(),
 				sniffer.Errors(),
@@ -592,6 +603,8 @@ func main() {
 	txnsReplayCmd.Flags().StringVar(&replayCfg.CometRPC, "sniffer-rpc", "http://127.0.0.1:26657", "RPC endpoint to use for the txns sniffer.")
 	txnsReplayCmd.Flags().Int64Var(&replayCfg.StartHeight, "sniffer-start-height", 0, "Start height for the txns sniffer (must be devnetified height + 1).")
 	txnsReplayCmd.Flags().Int64Var(&replayCfg.EndHeight, "sniffer-end-height", 0, "End height for the txns sniffer (optional, defaults to endless mode).")
+	txnsReplayCmd.Flags().StringVar(&replayCfg.FromFile, "from-file", "", "filepath to read sniffed txs from. If omitted, will sniff txs from RPC in realtime.")
+	txnsReplayCmd.Flags().StringVar(&replayCfg.ToFile, "to-file", "", "filepath to store sniffed txs into. If omitted, will replay sniffed txs in realtime.")
 
 	// Gas limit fuzzing configuration flags
 	txnsReplayCmd.Flags().BoolVar(&stressCfg.GasFuzzing.Enabled, "gas-fuzz", false, "Enable gas limit fuzzing for transactions during replay.")

--- a/cmd/chain-stresser/main.go
+++ b/cmd/chain-stresser/main.go
@@ -570,7 +570,10 @@ func main() {
 			}()
 
 			if replayCfg.ToFile != "" { // we just dumping txs, no replay needed
-				<-sniffer.Done()
+				select {
+				case <-sniffer.Errors():
+				case <-sniffer.Done():
+				}
 				return nil
 			}
 

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -4,4 +4,6 @@ type TxReplayConfig struct {
 	CometRPC    string `yaml:"cometRPC" arg:"--comet-rpc" help:"CometBFT JSON-RPC endpoint to query for transactions in blocks"`
 	StartHeight int64  `yaml:"startHeight" arg:"--start-height" help:"block height to start sniffing transactions from"`
 	EndHeight   int64  `yaml:"endHeight" arg:"--end-height" help:"block height to end sniffing transactions from. 0 = endless mode (real-time sniffing)"`
+	FromFile    string `yaml:"fromFile" arg:"--from-file" help:"filepath to read sniffed txs from. If omitted, will sniff txs from RPC in realtime."`
+	ToFile      string `yaml:"toFile" arg:"--to-file" help:"filepath to store sniffed txs into. If omitted, will replay sniffed txs in realtime."`
 }

--- a/replay/sniffer.go
+++ b/replay/sniffer.go
@@ -2,7 +2,10 @@ package replay
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
+	"io"
+	"os"
 	"time"
 
 	"github.com/avast/retry-go/v4"
@@ -16,6 +19,8 @@ const (
 	DEFAULT_RETRY_DELAY   = 5 * time.Second
 	DEFAULT_MAX_DELAY     = 60 * time.Second
 	DEFAULT_BLOCKS_BUFFER = 1000
+
+	BlockFromFileTxNum = 100
 )
 
 type Sniffer struct {
@@ -26,6 +31,8 @@ type Sniffer struct {
 	blocksCh chan *comettypes.Block
 	errCh    chan error
 	doneCh   chan struct{}
+	txsFile  io.Reader
+	dumpFile io.Writer
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -46,11 +53,27 @@ func NewSniffer(cfg *TxReplayConfig, ctx context.Context) (*Sniffer, error) {
 		cancel:   cancel,
 	}
 
-	c, err := rpchttp.New(s.cfg.CometRPC)
-	if err != nil {
-		return nil, fmt.Errorf("sniffer error: can't create rpc client: %w", err)
+	if cfg.FromFile == "" {
+		c, err := rpchttp.New(s.cfg.CometRPC)
+		if err != nil {
+			return nil, fmt.Errorf("sniffer error: can't create rpc client: %w", err)
+		}
+		s.rpcClient = c
+	} else {
+		if f, err := os.OpenFile(cfg.FromFile, os.O_RDONLY, 0644); err != nil {
+			return nil, fmt.Errorf("sniffer error: can't open txns file for reading: %w", err)
+		} else {
+			s.txsFile = f
+		}
 	}
-	s.rpcClient = c
+
+	if cfg.ToFile != "" {
+		if f, err := os.OpenFile(cfg.ToFile, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644); err != nil {
+			return nil, fmt.Errorf("sniffer error: can't open txns dump file for write: %w", err)
+		} else {
+			s.dumpFile = f
+		}
+	}
 
 	return s, nil
 }
@@ -97,13 +120,43 @@ func (s *Sniffer) run() {
 				default:
 				}
 
-				res, err := s.rpcClient.Block(s.ctx, &height)
-				if err != nil {
-					return err
+				var block *comettypes.Block
+
+				if s.cfg.FromFile != "" { // read BlockFromFileTxNum txs from file and construct virtual block
+					block = &comettypes.Block{
+						Data: comettypes.Data{
+							Txs: make([]comettypes.Tx, 0, BlockFromFileTxNum),
+						},
+					}
+					for i := 0; i < BlockFromFileTxNum; i++ {
+						tx, err := s.readTxFromFile()
+						if err != nil { // end of file or err
+							break
+						}
+						block.Txs = append(block.Txs, tx)
+					}
+
+					if len(block.Txs) == 0 {
+						block = nil // signal the end
+					}
+				} else {
+					res, err := s.rpcClient.Block(s.ctx, &height)
+					if err != nil {
+						return err
+					}
+
+					block = res.Block
+
+					if s.cfg.ToFile != "" { // just dump txs to file
+						if err := s.processBlock(block); err != nil {
+							return err
+						}
+						return nil
+					}
 				}
 
 				select {
-				case s.blocksCh <- res.Block:
+				case s.blocksCh <- block:
 				case <-s.ctx.Done():
 					return s.ctx.Err()
 				}
@@ -133,6 +186,47 @@ func (s *Sniffer) run() {
 	}
 
 	s.logger.Info("sniffing completed successfully")
+}
+
+func (s *Sniffer) processBlock(block *comettypes.Block) error {
+	if s.dumpFile != nil {
+		for _, txn := range block.Txs {
+			b := make([]byte, 8)
+			binary.LittleEndian.PutUint64(b, uint64(len(txn)))
+			if _, err := s.dumpFile.Write(append(b, txn...)); err != nil { // encoded as little-endian 8 bytes len + data
+				s.logger.WithFields(log.Fields{"err": err}).Fatal("can't write to output file")
+			}
+		}
+	}
+
+	s.logger.WithFields(log.Fields{"block_height": block.Header.Height, "num": len(block.Data.Txs)}).Info("sniffed")
+
+	return nil
+}
+
+func (s *Sniffer) readTxFromFile() ([]byte, error) {
+	var (
+		lenN   int
+		txnN   int
+		len    uint64
+		txnBuf []byte
+	)
+
+	lenBuf := make([]byte, 8)
+	lenN, _ = s.txsFile.Read(lenBuf)
+
+	if lenN > 0 {
+		len = binary.LittleEndian.Uint64(lenBuf)
+
+		txnBuf = make([]byte, len)
+		txnN, _ = s.txsFile.Read(txnBuf)
+	}
+
+	if lenN < 8 || uint64(txnN) < len {
+		return nil, fmt.Errorf("sniffer error: can't read tx from file")
+	}
+
+	return txnBuf, nil
 }
 
 // Exposed channel accessors

--- a/stresser.go
+++ b/stresser.go
@@ -416,9 +416,6 @@ func Stress(
 		spawn("accounts", parallel.Exit, func(ctx context.Context) error {
 			return parallel.Run(ctx, func(ctx context.Context, spawn parallel.SpawnFn) error {
 				for accountIdx, accountTxs := range signedTxs {
-					accountTxs := accountTxs
-					accountIdx := accountIdx
-
 					initialSequence := initialAccountSequences[accountIdx]
 
 					spawn(fmt.Sprintf("account-%d", accountIdx), parallel.Continue, func(ctx context.Context) error {


### PR DESCRIPTION
Adds two more flags to `tx-replay` command:

`--from-file`           filepath to read sniffed txs from. If omitted, will sniff txs from RPC in realtime.
`--to-file`             filepath to store sniffed txs into. If omitted, will replay sniffed txs in realtime.

When replaying from file, we batch txs into blocks by 100 tx each.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI options to read transactions from files for offline replay and to write sniffed transactions to files for recording.
  * CLI now enforces valid flag combinations and mutually exclusive modes (file vs realtime) to avoid misconfiguration.

* **Bug Fixes**
  * Fixed variable scope handling in the transaction broadcast phase to prevent concurrency issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->